### PR TITLE
Make Status/Registry models configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,41 @@ Generator stubs can be customized by publishing them (`--tag=flowra-stubs`) — 
 | `cache_driver` | `database` | Cache store used for workflow definitions (env: `FLOWRA_CACHE_DRIVER`) |
 | `tables.statuses` | `statuses` | Table holding each model's current state per workflow |
 | `tables.registry` | `statuses_registry` | Append-only transition history table |
+| `models.status` | `Flowra\Models\Status::class` | Eloquent class used for status rows |
+| `models.registry` | `Flowra\Models\Registry::class` | Eloquent class used for registry rows |
+
+### Using your own Status / Registry models
+
+Point `models.status` / `models.registry` at your own classes to add casts, relations, scopes, or
+other behavior to the rows Flowra writes. Your class **must extend** the corresponding Flowra
+model:
+
+```php
+namespace App\Models;
+
+use Flowra\Models\Status as BaseStatus;
+
+class Status extends BaseStatus
+{
+    public function approvedBy()
+    {
+        return $this->belongsTo(User::class, 'applied_by');
+    }
+}
+```
+
+```php
+// config/flowra.php
+'models' => [
+    'status' => \App\Models\Status::class,
+    'registry' => \App\Models\Registry::class,
+],
+```
+
+Every relation (`{alias}Status`, `{alias}Registry`, `statuses()`, `registry()`) and every internal
+read/write (`$workflow->status()`, `$workflow->registry()`, transition persistence) resolves the
+class through this config at call time, so the swap applies package-wide with no other code
+changes.
 
 ## Database Schema
 

--- a/src/Concretes/BaseWorkflow.php
+++ b/src/Concretes/BaseWorkflow.php
@@ -5,8 +5,9 @@ namespace Flowra\Concretes;
 use Flowra\Contracts\HasWorkflowContract;
 use Flowra\DTOs\BulkTransitionResult;
 use Flowra\DTOs\Transition;
-use Flowra\Models\{Registry, Status};
+use Flowra\Models\Status;
 use Flowra\Services\BulkTransitionService;
+use Flowra\Support\WorkflowModels;
 use Flowra\Traits\Support\Bootable;
 use Flowra\Traits\Workflow\{HasStates, HasTransitions};
 use Illuminate\Database\Eloquent\Collection;
@@ -31,7 +32,7 @@ class BaseWorkflow
 
     public function status(): ?Status
     {
-        return Status::query()
+        return WorkflowModels::status()::query()
             ->where('owner_type', $this->model->getMorphClass())
             ->where('owner_id', $this->model->getKey())
             ->where('workflow', $this::class)
@@ -40,7 +41,7 @@ class BaseWorkflow
 
     public function registry(): Collection
     {
-        return Registry::query()
+        return WorkflowModels::registry()::query()
             ->where('owner_type', $this->model->getMorphClass())
             ->where('owner_id', $this->model->getKey())
             ->where('workflow', $this::class)

--- a/src/Support/WorkflowModels.php
+++ b/src/Support/WorkflowModels.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Flowra\Support;
+
+use Flowra\Models\Registry;
+use Flowra\Models\Status;
+
+class WorkflowModels
+{
+    /**
+     * @return class-string<Status>
+     */
+    public static function status(): string
+    {
+        return config('flowra.models.status') ?? Status::class;
+    }
+
+    /**
+     * @return class-string<Registry>
+     */
+    public static function registry(): string
+    {
+        return config('flowra.models.registry') ?? Registry::class;
+    }
+}

--- a/src/Traits/HasWorkflowRelations.php
+++ b/src/Traits/HasWorkflowRelations.php
@@ -2,8 +2,7 @@
 
 namespace Flowra\Traits;
 
-use Flowra\Models\Registry;
-use Flowra\Models\Status;
+use Flowra\Support\WorkflowModels;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Str;
@@ -27,11 +26,11 @@ trait HasWorkflowRelations
             $alias = Str::camel(class_basename($class));
 
             static::resolveRelationUsing($alias.'Status', function (Model $model) use ($class) {
-                return $model->morphOne(Status::class, 'owner')->where('workflow', $class);
+                return $model->morphOne(WorkflowModels::status(), 'owner')->where('workflow', $class);
             });
 
             static::resolveRelationUsing($alias.'Registry', function (Model $model) use ($class) {
-                return $model->morphMany(Registry::class, 'owner')->where('workflow', $class);
+                return $model->morphMany(WorkflowModels::registry(), 'owner')->where('workflow', $class);
             });
         }
     }
@@ -43,7 +42,7 @@ trait HasWorkflowRelations
      */
     public function statuses(): MorphMany
     {
-        return $this->morphMany(Status::class, 'owner');
+        return $this->morphMany(WorkflowModels::status(), 'owner');
     }
 
     /**
@@ -53,6 +52,6 @@ trait HasWorkflowRelations
      */
     public function registry(): MorphMany
     {
-        return $this->morphMany(Registry::class, 'owner');
+        return $this->morphMany(WorkflowModels::registry(), 'owner');
     }
 }

--- a/src/Traits/Workflow/CanApplyTransitions.php
+++ b/src/Traits/Workflow/CanApplyTransitions.php
@@ -6,8 +6,8 @@ use Flowra\DTOs\Jump;
 use Flowra\DTOs\Transition;
 use Flowra\Exceptions\ApplyJumpException;
 use Flowra\Exceptions\ApplyTransitionException;
-use Flowra\Models\Registry;
 use Flowra\Models\Status;
+use Flowra\Support\WorkflowModels;
 use Illuminate\Support\Facades\DB;
 use Throwable;
 use UnitEnum;
@@ -139,7 +139,7 @@ trait CanApplyTransitions
      */
     private function saveStatus(Transition $t): Status
     {
-        return Status::query()->updateOrCreate(
+        return WorkflowModels::status()::query()->updateOrCreate(
             [
                 'owner_type' => $this->model->getMorphClass(),
                 'owner_id' => $this->model->getKey(),
@@ -163,7 +163,7 @@ trait CanApplyTransitions
      */
     private function appendToRegistry(Transition $t): void
     {
-        Registry::query()->create([
+        WorkflowModels::registry()::query()->create([
             'owner_type' => $this->model->getMorphClass(),
             'owner_id' => $this->model->getKey(),
             'workflow' => $this::class,

--- a/src/config/flowra.php
+++ b/src/config/flowra.php
@@ -45,6 +45,19 @@ return [
         'registry' => 'statuses_registry',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Models
+    |--------------------------------------------------------------------------
+    | Eloquent classes Flowra uses for status/registry rows. Point these at
+    | your own classes to add casts, relations, or behavior — they must
+    | extend the respective Flowra\Models class.
+    */
+    'models' => [
+        'status' => Flowra\Models\Status::class,
+        'registry' => Flowra\Models\Registry::class,
+    ],
+
 //    // Define the workflow stubs directory
 //    'stubs_dir' => base_path('stubs/workflow'),
 //


### PR DESCRIPTION
Add support for custom Status and Registry Eloquent models through configuration.

Introduces WorkflowModels support class to centralize resolution of configured model classes. Users can now extend Flowra's Status and Registry models to add custom casts, relations, or behavior by configuring models.status and models.registry in flowra.php.

All internal queries and relations now resolve model classes through this config at call time, enabling package-wide swaps without code changes. Includes documentation and examples for using custom models.